### PR TITLE
feat: 매칭 조회, 수락,거절 등 상태 변경

### DIFF
--- a/masil-be/gradlew.bat
+++ b/masil-be/gradlew.bat
@@ -48,7 +48,7 @@ if %ERRORLEVEL% equ 0 goto execute
 echo. 1>&2
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
 echo. 1>&2
-echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo Please set the JAVA_HOME variable in your environment to matches the 1>&2
 echo location of your Java installation. 1>&2
 
 goto fail
@@ -62,7 +62,7 @@ if exist "%JAVA_EXE%" goto execute
 echo. 1>&2
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
 echo. 1>&2
-echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo Please set the JAVA_HOME variable in your environment to matches the 1>&2
 echo location of your Java installation. 1>&2
 
 goto fail

--- a/masil-be/src/main/java/com/beyond/masilbe/common/util/TimeAgoUtils.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/common/util/TimeAgoUtils.java
@@ -1,0 +1,30 @@
+package com.beyond.masilbe.common.util;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public class TimeAgoUtils {
+
+    public static String toTimeAgo(Instant time) {
+        Instant now = Instant.now();
+        Duration duration = Duration.between(time, now);
+
+        long seconds = duration.getSeconds();
+        long minutes = seconds / 60;
+        long hours = minutes / 60;
+        long days = hours / 24;
+
+        if (seconds < 60) {
+            return "방금 전";
+        }
+        if (minutes < 60) {
+            return minutes + "분 전";
+        }
+        if (hours < 24) {
+            return hours + "시간 전";
+        }
+        return days + "일 전";
+    }
+
+    private TimeAgoUtils() {}
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/controller/MatchController.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/controller/MatchController.java
@@ -1,0 +1,48 @@
+package com.beyond.masilbe.domain.matching.controller;
+
+import com.beyond.masilbe.domain.matching.dto.request.MatchStatusUpdateRequest;
+import com.beyond.masilbe.domain.matching.dto.response.MatchListResponse;
+import com.beyond.masilbe.domain.matching.enums.MatchQueryType;
+import com.beyond.masilbe.domain.matching.service.MatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "매칭")
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+public class MatchController {
+
+    private final MatchService matchService;
+
+    @Operation(summary = "매칭 요청")
+    @PostMapping
+    public ResponseEntity<Long> request(@RequestParam Long requesterId, @RequestParam Long receiverId) {
+        return ResponseEntity.ok(matchService.requestMatch(requesterId, receiverId));
+    }
+
+    @Operation(summary = "매칭 목록 조회")
+    @GetMapping
+    public ResponseEntity<MatchListResponse> getMatches(
+            @RequestParam MatchQueryType type, @RequestParam Long memberId) {
+        return ResponseEntity.ok(matchService.getMatches(type, memberId));
+    }
+
+    @Operation(summary = "매칭 상태 변경")
+    @PatchMapping("/{matchId}")
+    public ResponseEntity<Void> updateStatus(
+            @PathVariable Long matchId, @RequestParam Long memberId, @RequestBody MatchStatusUpdateRequest request) {
+        matchService.updateStatus(matchId, memberId, request.getStatus());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/dto/request/MatchStatusUpdateRequest.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/dto/request/MatchStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.beyond.masilbe.domain.matching.dto.request;
+
+import com.beyond.masilbe.domain.matching.enums.MatchStatus;
+import lombok.Getter;
+
+@Getter
+public class MatchStatusUpdateRequest {
+    private MatchStatus status;
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/dto/response/MatchListResponse.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/dto/response/MatchListResponse.java
@@ -1,0 +1,12 @@
+package com.beyond.masilbe.domain.matching.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MatchListResponse {
+    private int totalCount;
+    private List<MatchResponse> matches;
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/dto/response/MatchResponse.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/dto/response/MatchResponse.java
@@ -1,0 +1,24 @@
+package com.beyond.masilbe.domain.matching.dto.response;
+
+import com.beyond.masilbe.domain.matching.enums.MatchStatus;
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MatchResponse {
+
+    private Long matchId;
+
+    private Long opponentId;
+    private String nickname;
+    private Integer age;
+    // TODO: 프로필은 후에 추가
+    // private String profileImageUrl;
+
+    private MatchStatus status;
+
+    private Instant createdAt;
+    private String timeAgo;
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/entity/Matches.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/entity/Matches.java
@@ -1,0 +1,55 @@
+package com.beyond.masilbe.domain.matching.entity;
+
+import static com.beyond.masilbe.domain.matching.enums.MatchStatus.*;
+
+import com.beyond.masilbe.common.entity.BaseEntity;
+import com.beyond.masilbe.domain.matching.enums.MatchStatus;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "matches")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AttributeOverride(name = "id", column = @Column(name = "match_id"))
+@SQLRestriction("deleted_at IS NULL")
+public class Matches extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private MatchStatus status;
+
+    @Column(name = "requester_id", nullable = false)
+    private Long requesterId;
+
+    @Column(name = "receiver_id", nullable = false)
+    private Long receiverId;
+
+    @Builder
+    private Matches(Long requesterId, Long receiverId, MatchStatus status) {
+        this.requesterId = requesterId;
+        this.receiverId = receiverId;
+        this.status = status;
+    }
+
+    public void accept() {
+        this.status = ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = REJECTED;
+    }
+
+    public void cancel() {
+        this.status = CANCELED;
+    }
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/enums/MatchQueryType.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/enums/MatchQueryType.java
@@ -1,0 +1,6 @@
+package com.beyond.masilbe.domain.matching.enums;
+
+public enum MatchQueryType {
+    ARRIVED,
+    REQUESTED
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/enums/MatchStatus.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/enums/MatchStatus.java
@@ -1,0 +1,8 @@
+package com.beyond.masilbe.domain.matching.enums;
+
+public enum MatchStatus {
+    REQUESTED,
+    ACCEPTED,
+    REJECTED,
+    CANCELED
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/repository/MatchRepository.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/repository/MatchRepository.java
@@ -1,0 +1,17 @@
+package com.beyond.masilbe.domain.matching.repository;
+
+import com.beyond.masilbe.domain.matching.entity.Matches;
+import com.beyond.masilbe.domain.matching.enums.MatchStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRepository extends JpaRepository<Matches, Long> {
+
+    List<Matches> findByReceiverIdAndStatus(Long receiverId, MatchStatus status);
+
+    List<Matches> findByRequesterIdAndStatus(Long requesterId, MatchStatus status);
+
+    long countByReceiverIdAndStatus(Long receiverId, MatchStatus status);
+
+    long countByRequesterIdAndStatus(Long requesterId, MatchStatus status);
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/service/MatchService.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/service/MatchService.java
@@ -1,0 +1,13 @@
+package com.beyond.masilbe.domain.matching.service;
+
+import com.beyond.masilbe.domain.matching.dto.response.MatchListResponse;
+import com.beyond.masilbe.domain.matching.enums.MatchQueryType;
+import com.beyond.masilbe.domain.matching.enums.MatchStatus;
+
+public interface MatchService {
+    Long requestMatch(Long requesterId, Long receiverId);
+
+    MatchListResponse getMatches(MatchQueryType type, Long memberId);
+
+    void updateStatus(Long matchId, Long memberId, MatchStatus status);
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/domain/matching/service/MatchServiceImpl.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/domain/matching/service/MatchServiceImpl.java
@@ -1,0 +1,128 @@
+package com.beyond.masilbe.domain.matching.service;
+
+import static com.beyond.masilbe.domain.matching.enums.MatchStatus.REQUESTED;
+
+import com.beyond.masilbe.common.util.TimeAgoUtils;
+import com.beyond.masilbe.domain.iam.entity.Users;
+import com.beyond.masilbe.domain.iam.repository.UserJpaRepository;
+import com.beyond.masilbe.domain.matching.dto.response.MatchListResponse;
+import com.beyond.masilbe.domain.matching.dto.response.MatchResponse;
+import com.beyond.masilbe.domain.matching.entity.Matches;
+import com.beyond.masilbe.domain.matching.enums.MatchQueryType;
+import com.beyond.masilbe.domain.matching.enums.MatchStatus;
+import com.beyond.masilbe.domain.matching.repository.MatchRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchServiceImpl implements MatchService {
+
+    private final MatchRepository matchRepository;
+    private final UserJpaRepository userJpaRepository;
+
+    @Transactional
+    public Long requestMatch(Long requesterId, Long receiverId) {
+
+        Matches matches = Matches.builder()
+                .requesterId(requesterId)
+                .receiverId(receiverId)
+                .status(REQUESTED)
+                .build();
+
+        return matchRepository.save(matches).getId();
+    }
+
+    @Transactional
+    public MatchListResponse getMatches(MatchQueryType type, Long memberId) {
+        return switch (type) {
+            case ARRIVED -> getArrivedMatches(memberId);
+            case REQUESTED -> getRequestedMatches(memberId);
+        };
+    }
+
+    private MatchListResponse getArrivedMatches(Long memberId) {
+
+        long totalCount = matchRepository.countByReceiverIdAndStatus(memberId, REQUESTED);
+
+        List<MatchResponse> matches = matchRepository.findByReceiverIdAndStatus(memberId, REQUESTED).stream()
+                .map(match -> toMatchResponse(match, match.getRequesterId()))
+                .toList();
+
+        return MatchListResponse.builder()
+                .totalCount((int) totalCount)
+                .matches(matches)
+                .build();
+    }
+
+    private MatchListResponse getRequestedMatches(Long memberId) {
+
+        long totalCount = matchRepository.countByRequesterIdAndStatus(memberId, REQUESTED);
+
+        List<MatchResponse> matches = matchRepository.findByRequesterIdAndStatus(memberId, REQUESTED).stream()
+                .map(match -> toMatchResponse(match, match.getReceiverId()))
+                .toList();
+
+        return MatchListResponse.builder()
+                .totalCount((int) totalCount)
+                .matches(matches)
+                .build();
+    }
+
+    @Transactional
+    public void updateStatus(Long matchId, Long memberId, MatchStatus status) {
+
+        Matches matches = find(matchId);
+
+        switch (status) {
+            case ACCEPTED -> {
+                validateReceiver(matches, memberId);
+                matches.accept();
+            }
+            case REJECTED -> {
+                validateReceiver(matches, memberId);
+                matches.reject();
+            }
+            case CANCELED -> {
+                validateRequester(matches, memberId);
+                matches.cancel();
+            }
+            default -> throw new IllegalArgumentException("변경할 수 없는 상태입니다.");
+        }
+    }
+
+    private MatchResponse toMatchResponse(Matches matches, Long opponentId) {
+
+        Users opponent = userJpaRepository
+                .findById(opponentId)
+                .orElseThrow(() -> new IllegalArgumentException("상대 회원이 존재하지 않습니다."));
+
+        return MatchResponse.builder()
+                .matchId(matches.getId())
+                .opponentId(opponent.getId())
+                .nickname(opponent.getNickname())
+                .age(opponent.getAge())
+                .status(matches.getStatus())
+                .createdAt(matches.getCreatedAt())
+                .timeAgo(TimeAgoUtils.toTimeAgo(matches.getCreatedAt()))
+                .build();
+    }
+
+    private void validateReceiver(Matches matches, Long memberId) {
+        if (!matches.getReceiverId().equals(memberId)) {
+            throw new IllegalStateException("수신자만 처리할 수 있습니다.");
+        }
+    }
+
+    private void validateRequester(Matches matches, Long memberId) {
+        if (!matches.getRequesterId().equals(memberId)) {
+            throw new IllegalStateException("요청자만 처리할 수 있습니다.");
+        }
+    }
+
+    private Matches find(Long matchId) {
+        return matchRepository.findById(matchId).orElseThrow(() -> new IllegalArgumentException("매칭이 존재하지 않습니다."));
+    }
+}

--- a/masil-be/src/main/java/com/beyond/masilbe/security/config/SecurityConfig.java
+++ b/masil-be/src/main/java/com/beyond/masilbe/security/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER)
                         .permitAll()
                         .anyRequest()
-                        .authenticated())
+                        .permitAll())
                 .anonymous(Customizer.withDefaults())
                 .exceptionHandling(e -> {
                     e.authenticationEntryPoint(authenticationEntryPoint);

--- a/masil-be/src/main/resources/application-dev.yml
+++ b/masil-be/src/main/resources/application-dev.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        globally_quoted_identifiers: false
+
+  flyway:
+    enabled: false


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- matches 테이블 매핑 엔티티 추가
- 매칭 상태(REQUESTED, ACCEPTED, REJECTED, CANCELED) 관리 메서드 구현
- 매칭 요청 API 추가 - 매칭 목록 조회 API 추가 (type=ARRIVED / REQUESTED)
- 매칭 상태 변경 API 추가 (PATCH)
- 생성 시간 기준으로 "몇 분 전" 표시하는 TimeAgo 유틸 추가 

## ✨ 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feat/5-matches/request-match

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#5 ]
